### PR TITLE
Add develop branch to CI workflow triggers

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,9 +5,12 @@ name: .NET
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+      - develop    
   pull_request:
-    branches: [ "main" ]
+      - main
+      - develop
 
 jobs:
   build:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
## Pull Request Overview

Updates the GitHub Actions workflows to include the `develop` branch in CI triggers.

- Added `develop` branch to push events in SonarQube workflow.
- Expanded branch filters in .NET workflow to include `develop` for push and pull_request.