### PR TITLE
Remove --no-restore from dotnet build step

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,6 +26,6 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build
     - name: Test
       run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
The build step in the GitHub Actions workflow now runs 'dotnet build' without the '--no-restore' flag, ensuring dependencies are restored during the build process.