### PR TITLE
Fix incorrect syntax in dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,6 +26,6 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build
     - name: Test
       run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,8 +7,9 @@ on:
   push:
     branches:
       - main
-      - develop    
+      - develop
   pull_request:
+    branches:
       - main
       - develop
 


### PR DESCRIPTION
## Pull Request Overview

Fix incorrect syntax in the GitHub Actions workflow by properly specifying the pull_request branches filter and simplifying the build command.

- Added a `branches:` key under `pull_request` trigger
- Updated the build step to remove the `--no-restore` flag